### PR TITLE
Settable corner "snap to mouse" threshold

### DIFF
--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -38,6 +38,8 @@ void ofxGLWarper::setup(int _x, int _y, int _w, int _h){
 	width=_w;
 	height=_h;
 	whichCorner = -1;
+    
+    cornerSensibility = 0.5;
 }
 //--------------------------------------------------------------
 bool ofxGLWarper::isActive(){
@@ -237,7 +239,7 @@ void ofxGLWarper::mousePressed(ofMouseEventArgs &args){
 		float disty = corners[i].y - (float)args.y/height;
 		float dist  = sqrt( distx * distx + disty * disty);
 		
-		if(dist < smallestDist && dist < 0.5){
+		if(dist < smallestDist && dist < cornerSensibility){
 			whichCorner = i;
 			smallestDist = dist;
 		}
@@ -311,4 +313,14 @@ ofVec4f ofxGLWarper::fromWarpToScreenCoord(float x, float y, float z)
 	warpedPoint.z = warpedPoint.z / warpedPoint.w;
 	
 	return warpedPoint;
+}
+//--------------------------------------------------------------
+void ofxGLWarper::setCornerSensibility(float sensibility)
+{
+    cornerSensibility = sensibility;
+}
+//--------------------------------------------------------------
+float ofxGLWarper::getCornerSensibility()
+{
+    return cornerSensibility;
 }

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -39,6 +39,9 @@ public:
 	
 	ofVec4f		fromScreenToWarpCoord(float x,float y,float z);
 	ofVec4f		fromWarpToScreenCoord(float x,float y,float z);
+    
+    void setCornerSensibility(float sensibility);
+    float getCornerSensibility();
 
 private:
 	int x, y;
@@ -48,6 +51,7 @@ private:
 	ofPoint corners[4];
 	int whichCorner;
 	GLfloat myMatrix[16];
+    float cornerSensibility;
 };
 
 #endif	


### PR DESCRIPTION
I often find myself in very frustrating situations (eg.: while manipulating a gui panel on top of the warper) when the corners snap to the mouse position even if they are considerably far from where the click was originated.

By using a smaller threshold, usability gets highly improved, as you can control other things without interfering with the warper. Hence this simple getter/setter to allow manipulation of the threshold.
