### PR TITLE
Save/load from XML object

### DIFF
--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -214,7 +214,45 @@ void ofxGLWarper::load(string loadFile){
 	}
 	
 	processMatrices();
-	ofLog(OF_LOG_ERROR, "ofxGLWarper : xml file loaded OK!.");
+	ofLog(OF_LOG_WARNING, "ofxGLWarper : xml file loaded OK!.");
+	
+}
+//--------------------------------------------------------------
+void ofxGLWarper::saveToXml(ofxXmlSettings &XML){
+	XML.clear();
+	XML.addTag("corners");
+	XML.pushTag("corners");
+	
+	
+	for(int i =0; i<4; i++){
+		int t = XML.addTag("corner");
+		XML.setValue("corner:x",corners[i].x, t);
+		XML.setValue("corner:y",corners[i].y, t);
+	}
+}
+//--------------------------------------------------------------
+void ofxGLWarper::loadFromXml(ofxXmlSettings &XML){	
+	if(!XML.tagExists("corners")){
+		ofLog(OF_LOG_ERROR, "ofxGLWarper : incorrrect xml formating. No \"corners\" tag found");
+		return;
+	}
+	XML.pushTag("corners");
+	if (XML.getNumTags("corner")<4 ) {
+		ofLog(OF_LOG_ERROR, "ofxGLWarper : incorrrect xml formating. less than 4 \"corner\" tags found");
+		return;
+	}
+	for(int i =0; i<4; i++){
+		int t = XML.addTag("corner");
+		XML.pushTag("corner", i);
+		if (XML.tagExists("x") && XML.tagExists("y")){
+			corners[i].x = XML.getValue("x", double(1.0));
+			corners[i].y = XML.getValue("y", double(1.0));
+		}
+		XML.popTag();
+	}
+	
+	processMatrices();
+	ofLog(OF_LOG_WARNING, "ofxGLWarper : xml object loaded OK!.");
 	
 }
 //--------------------------------------------------------------

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -33,6 +33,9 @@ public:
 	void save(string saveFile = "warpConfig.xml");
 	void load(string loadFile = "warpConfig.xml");
 	
+	void saveToXml(ofxXmlSettings& XML);
+	void loadFromXml(ofxXmlSettings& XML);
+	
 	void activate();
 	void deactivate();
 	bool isActive();


### PR DESCRIPTION
Following the pattern of ofxGui, added methods to load and save also from XML objects.
In that way you can apply settings also from objects already loaded in memory.

This commit also changed `OF_LOG_ERROR` to `OF_LOG_WARNING` on the line 217:

```
ofLog(OF_LOG_WARNING, "ofxGLWarper : xml file loaded OK!.");
```

This reports success, so it shouldn't be treated as an error...
