### PR TITLE
optionally customize xml, event triggers added

### DIFF
--- a/example-MultiWarpers/src/ofApp.cpp
+++ b/example-MultiWarpers/src/ofApp.cpp
@@ -39,7 +39,6 @@ void ofApp::keyPressed(int key){
             warpers[0].toggleActive();
             bDeactivateOthers =true;
             break;
-            //*
         case '2':
             activeWarper=1;
             warpers[1].toggleActive();
@@ -56,7 +55,32 @@ void ofApp::keyPressed(int key){
             warpers[3].toggleActive();
             break; 
             //*/
-            default:
+        default:
+            //here are two methods of saving:
+            //the first one saves multiple warpers in the same file, but you have to manage an ofXml object.
+            if (key == 's'){
+                for (unsigned int var = 0; var < NUM_WARPERS; ++var) {
+                    warpers[var].saveToXml(XML, "warper" + ofToString(var));
+                }
+                XML.save("saveFile.xml");
+            }
+            if (key == 'l'){
+                XML.load("saveFile.xml");
+                for (unsigned int var = 0; var < NUM_WARPERS; ++var) {
+                    warpers[var].loadFromXml(XML, "warper" + ofToString(var));
+                }
+            }
+            //the second one is one file per save, but you don't have to manage an ofXml object.
+            if (key == 'S'){
+                for (unsigned int var = 0; var < NUM_WARPERS; ++var) {
+                warpers[var].save("warper" + ofToString(var) + ".xml");
+                }
+            }
+            if (key == 'L'){
+                for (unsigned int var = 0; var < NUM_WARPERS; ++var) {
+                warpers[var].load("warper" + ofToString(var) + ".xml");
+                }
+            }
             break;
     }
     

--- a/example-MultiWarpers/src/ofApp.h
+++ b/example-MultiWarpers/src/ofApp.h
@@ -21,7 +21,8 @@ class ofApp : public ofBaseApp{
 		void mouseReleased();
 
 		vector<ofxGLWarper> warpers;
-	
+
+        ofXml XML;
 		ofImage img;
     int activeWarper;
 };

--- a/example-events/src/ofApp.cpp
+++ b/example-events/src/ofApp.cpp
@@ -57,11 +57,6 @@ void ofApp::draw(){
     ofDrawCircle(BLPosition, 15);
     ofDrawCircle(BRPosition, 15);
 
-    //this is an alternative if you don't want to put a listener
-//    ofDrawCircle(warper.getCorner(ofxGLWarper::TOP_LEFT), 15);
-//    ofDrawCircle(warper.getCorner(ofxGLWarper::TOP_RIGHT), 15);
-//    ofDrawCircle(warper.getCorner(ofxGLWarper::BOTTOM_LEFT), 15);
-//    ofDrawCircle(warper.getCorner(ofxGLWarper::BOTTOM_RIGHT), 15);
 }
 
 //--------------------------------------------------------------
@@ -80,5 +75,15 @@ void ofApp::onCornerChange(ofxGLWarper::CornerLocation & cornerLocation){
             BRPosition = warper.getCorner(cornerLocation);
             break;
 
+    }
+}
+
+void ofApp::keyPressed(int key){
+    if (key == 't'){
+        ofPoint tl(100, 100);
+        ofPoint tr(ofGetWidth()-100, 100);
+        ofPoint bl(100, ofGetHeight()-100);
+        ofPoint br(ofGetWidth()-100, ofGetHeight()-100);
+        warper.setAllCorners(tl,tr,bl,br);
     }
 }

--- a/example-events/src/ofApp.h
+++ b/example-events/src/ofApp.h
@@ -8,6 +8,7 @@ public:
     void setup();
     void update();
     void draw();
+    void keyPressed(int key);
     
     void onCornerChange(ofxGLWarper::CornerLocation &cornerLocation);
     

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -158,15 +158,16 @@ void ofxGLWarper::end(){
     }
 }
 //--------------------------------------------------------------
-void ofxGLWarper::save(string saveFile){
+void ofxGLWarper::save(const string &saveFile){
     ofXml XML;
     saveToXml(XML);
     XML.save(saveFile);
 }
 //--------------------------------------------------------------
-void ofxGLWarper::saveToXml(ofXml &XML){
+void ofxGLWarper::saveToXml(ofXml &XML, const string& warperID){
     
-    auto c = XML.appendChild("corners");
+    XML.removeChild(warperID);//if child doesn't exist yet, it's ok.
+    auto c = XML.appendChild(warperID);
     for(int i =0; i<4; i++){
 		auto nc = c.appendChild("corner");
 		nc.appendChild("x").set(corners[i].x);
@@ -175,7 +176,7 @@ void ofxGLWarper::saveToXml(ofXml &XML){
     c.appendChild("active").set(active);
 }
 //--------------------------------------------------------------
-void ofxGLWarper::load(string loadFile){
+void ofxGLWarper::load(const string &loadFile){
     ofXml XML;
     if( !XML.load(loadFile) ){
         ofLog(OF_LOG_ERROR, "ofxGLWarper : xml file not loaded. Check file path.");
@@ -185,10 +186,10 @@ void ofxGLWarper::load(string loadFile){
 }
 
 //--------------------------------------------------------------
-void ofxGLWarper::loadFromXml(ofXml &XML){
-	auto c = XML.getChild("corners");
+void ofxGLWarper::loadFromXml(ofXml &XML, const string& warperID){
+    auto c = XML.getChild(warperID);
     if(!c){
-        ofLog(OF_LOG_ERROR, "ofxGLWarper : incorrrect xml formating. No \"corners\" tag found");
+        ofLog(OF_LOG_ERROR, "ofxGLWarper : incorrrect xml formating. No \"" + warperID + "\" tag found");
         return;
     }
 	
@@ -203,10 +204,11 @@ void ofxGLWarper::loadFromXml(ofXml &XML){
 		corners[i].y = ch.getChild("y").getFloatValue();
 		i++;
     }
-    active = c.getChild("active").getBoolValue();
+
+    (c.getChild("active").getBoolValue()) ? this->activate() : this->deactivate() ;
 
     processMatrices();
-    ofLog(OF_LOG_WARNING, "ofxGLWarper : xml object loaded OK!.");
+    //ofLog(OF_LOG_WARNING, "ofxGLWarper : xml object loaded OK!."); // Since the method works, this can be quiet...
 
 }
 //--------------------------------------------------------------

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -335,6 +335,15 @@ void ofxGLWarper::setAllCorners(ofPoint& top_left, ofPoint &top_right, ofPoint &
     corners[BOTTOM_RIGHT] = bot_right;
 
     processMatrices();
+
+    CornerLocation location = TOP_LEFT;
+    ofNotifyEvent(changeEvent, location, this);
+    location = TOP_RIGHT;
+    ofNotifyEvent(changeEvent, location, this);
+    location = BOTTOM_RIGHT;
+    ofNotifyEvent(changeEvent, location, this);
+    location = BOTTOM_LEFT;
+    ofNotifyEvent(changeEvent, location, this);
 }
 //--------------------------------------------------------------
 ofPoint ofxGLWarper::getCorner(CornerLocation cornerLocation){

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -43,11 +43,11 @@ public:
     
 	void processMatrices();
 	
-	void save(string saveFile = "warpConfig.xml");
-	void load(string loadFile = "warpConfig.xml");
+    void save(const string& saveFile = "warpConfig.xml");
+    void load(const string& loadFile = "warpConfig.xml");
 	
-	void saveToXml(ofXml& XML);
-	void loadFromXml(ofXml& XML);
+    void saveToXml(ofXml& XML, const string& warperID = "corners");
+    void loadFromXml(ofXml& XML, const string& warperID = "corners");
 	
     void toggleActive();
 	void activate();


### PR DESCRIPTION
I absolutely agree that saving is needed, but I would question if it has to be dealt inside the addon.
Anyway, this will live there peacefully, and I added an optional argument if you want to handle the Xml object yourself and customize the xml naming system, in order to avoid having one file per warper in case of multiple warpers (I included it in the multiWarp example).
For events, I trust you so I added events triggers to setAllCorners().