### PR TITLE
coords fixed, reSetupWarped() and question draw()

### DIFF
--- a/example-MultiWarpers/src/ofApp.cpp
+++ b/example-MultiWarpers/src/ofApp.cpp
@@ -6,7 +6,7 @@ void ofApp::setup(){
     for (unsigned int i =0; i<NUM_WARPERS; i++){
         warpers.push_back(ofxGLWarper());
         warpers.back().setup((i%2)*img.getWidth(),floor(float(i)/2)*img.getHeight(),img.getWidth(), img.getHeight());
-       //warpers.back().activate();
+		warpers.back().drawSettings.bDrawRectangle = true; // default: true. Check drawSettings options for customization.
     }
     //ofSetVerticalSync(true); // is enabled by default since OF 0.8
 	
@@ -23,8 +23,7 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
     for (unsigned int i =0; i<NUM_WARPERS; i++){
-        warpers[i].begin();	
-        warpers[i].draw(); 
+        warpers[i].begin();
         img.draw((i%2)*img.getWidth(),floor(float(i)/2)*img.getHeight());
         warpers[i].end();
 	}

--- a/example-Super_simple/src/ofApp.cpp
+++ b/example-Super_simple/src/ofApp.cpp
@@ -11,6 +11,7 @@ void ofApp::setup(){
 	warper.activate();// this allows ofxGLWarper to automatically listen to the mouse and keyboard input and updates automatically it's matrixes.
 
     ofBackground(20, 20, 20);
+	warper.drawSettings.bDrawRectangle = true; // default: true. Check drawSettings options for customization.
 }
 
 //--------------------------------------------------------------
@@ -23,7 +24,6 @@ void ofApp::draw(){
 
     warper.begin();	///all the things that are drawn AFTER ofxGLWarper's begin method are afected by it.
 					///el metodo draw de ofxGLWarper afecta a todos los elementos dibujados despues si.
-	warper.draw(); //when active, ofxGLWarper draws a rectangle around the warped area.
 	// -- NOW LETS DRAW!!!!!!  -----
 	
 	img.draw(70, 120);

--- a/example-events/src/ofApp.cpp
+++ b/example-events/src/ofApp.cpp
@@ -31,6 +31,8 @@ void ofApp::setup(){
     warper.corners[1].addListener(this, &ofApp::onCornerChange);
     warper.corners[2].addListener(this, &ofApp::onCornerChange);
     warper.corners[3].addListener(this, &ofApp::onCornerChange);
+	
+	warper.drawSettings.bDrawRectangle = false; // default: true. Check drawSettings options for customization.
 
 }
 

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -267,8 +267,8 @@ glm::vec4 ofxGLWarper::fromScreenToWarpCoord(float x, float y, float z){
     glm::vec4 warpedPoint;
 
     // this is the point on the image which i want to know the coordinates inside the warped system ...
-    mousePoint.x = x;
-    mousePoint.y = y;
+    mousePoint.x = x - (this->x);
+    mousePoint.y = y - (this->y);
     mousePoint.z = z;
     mousePoint.w = 1.0;
 
@@ -302,8 +302,8 @@ glm::vec4 ofxGLWarper::fromWarpToScreenCoord(float x, float y, float z){
     // multiply both to get the point transformed by the matrix
     warpedPoint = invertedMyMatrix * mousePoint ;
 
-    warpedPoint.x = warpedPoint.x / warpedPoint.w;
-    warpedPoint.y = warpedPoint.y / warpedPoint.w;
+    warpedPoint.x = warpedPoint.x / warpedPoint.w + (this->x);
+    warpedPoint.y = warpedPoint.y / warpedPoint.w + (this->y);
     warpedPoint.z = warpedPoint.z / warpedPoint.w;
 
     return warpedPoint;

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -149,14 +149,14 @@ void ofxGLWarper::begin(){
 }
 //--------------------------------------------------------------
 void ofxGLWarper::end(){
-    if (drawSettings.bDrawRectangle && active) {
+    if ((drawSettings.bDrawRectangle && active) || (drawSettings.bDrawRectangle && drawSettings.bForceDrawing)) {
         ofPushStyle();
         ofSetColor(drawSettings.rectangleColor);
         ofNoFill();
         ofDrawRectangle(x, y, width, height);
     }
     ofPopMatrix();
-    if (drawSettings.bDrawCorners && active) {// this draws colored squares over the corners as a visual aid.
+    if ((drawSettings.bDrawCorners && active) || (drawSettings.bDrawCorners && drawSettings.bForceDrawing)) {// this draws colored squares over the corners as a visual aid.
         ofSetRectMode(OF_RECTMODE_CENTER);
         for (int i = 0; i < 4; i++) {
             if(i==selectedCorner){

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -151,7 +151,7 @@ void ofxGLWarper::begin(){
 void ofxGLWarper::end(){
     if (drawSettings.bDrawRectangle && active) {
         ofPushStyle();
-        ofSetColor(drawSettings.RectangleColor);
+        ofSetColor(drawSettings.rectangleColor);
         ofNoFill();
         ofDrawRectangle(x, y, width, height);
     }

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -38,6 +38,23 @@ void ofxGLWarper::setup(int _x, int _y, int _w, int _h){
 
     processMatrices();
 }
+
+//--------------------------------------------------------------
+void ofxGLWarper::reSetupWarped(int _x, int _y, int _w, int _h){
+
+    corners[TOP_LEFT] =     glm::vec2(fromScreenToWarpCoord( _x      , _y        ));
+    corners[TOP_RIGHT] =    glm::vec2(fromScreenToWarpCoord( _x + _w , _y        ));
+    corners[BOTTOM_RIGHT] = glm::vec2(fromScreenToWarpCoord( _x + _w , _y + _h   ));
+    corners[BOTTOM_LEFT] =  glm::vec2(fromScreenToWarpCoord( _x      , _y + _h   ));
+
+    x=_x;
+    y=_y;
+    width=_w;
+    height=_h;
+
+    processMatrices();
+}
+
 //--------------------------------------------------------------
 bool ofxGLWarper::isActive(){
     return active;

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -139,14 +139,7 @@ void ofxGLWarper::processMatrices(){
 
 }
 //--------------------------------------------------------------
-void ofxGLWarper::draw(){
-    if (active) {
-        ofPushStyle();
-        ofSetColor(255, 255, 255);
-        ofNoFill();
-        ofDrawRectangle(x, y, width, height);
-        ofPopStyle();
-    }
+void ofxGLWarper::draw(){ // Deprecated (included in end()). Please check the drawSettings structure.
 }
 //--------------------------------------------------------------
 void ofxGLWarper::begin(){
@@ -156,16 +149,22 @@ void ofxGLWarper::begin(){
 }
 //--------------------------------------------------------------
 void ofxGLWarper::end(){
-    ofPopMatrix();
-    if (active) {// this draws colored squares over the corners as a visual aid.
+    if (drawSettings.bDrawRectangle && active) {
         ofPushStyle();
+        ofSetColor(drawSettings.RectangleColor);
+        ofNoFill();
+        ofDrawRectangle(x, y, width, height);
+    }
+    ofPopMatrix();
+    if (drawSettings.bDrawCorners && active) {// this draws colored squares over the corners as a visual aid.
         ofSetRectMode(OF_RECTMODE_CENTER);
         for (int i = 0; i < 4; i++) {
             if(i==selectedCorner){
-                ofSetColor(255, 0, 0);
+                ofSetColor(drawSettings.selectedCornerColor);
             }else{
-                ofSetColor(255, 255, 0);
+                ofSetColor(drawSettings.cornersColor);
             }
+            ofFill();
             ofDrawRectangle(corners[i], 10, 10);
         }
         ofPopStyle();

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -26,6 +26,9 @@ public:
 	void setup();		
 	void setup(int _resX, int _resY); //changed to have resolution as parameter for the quad
 	void setup(int _x, int _y, int _w, int _h);
+
+    void reSetupWarped(int _x, int _y, int _w, int _h); // allows you to redefine base rectangle without losing the current warping.
+
 	void draw();	// nowthis method draw the bounding box for the warped elements. intended to be a visual aid.
 	void begin();	//changed name from draw to begin
 	void end();		//added to make it easier to use, similar to ofFbo (begin,end)

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -83,6 +83,7 @@ public:
     struct drawSettings{
         bool bDrawCorners = true;
         bool bDrawRectangle = true;
+        bool bForceDrawing = false; // Draws warper even if not active.
         ofColor selectedCornerColor = ofColor(255, 0, 0);
         ofColor cornersColor = ofColor(255, 255, 0);
         ofColor rectangleColor = ofColor(255, 255, 255);

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -85,7 +85,7 @@ public:
         bool bDrawRectangle = true;
         ofColor selectedCornerColor = ofColor(255, 0, 0);
         ofColor cornersColor = ofColor(255, 255, 0);
-        ofColor RectangleColor = ofColor(255, 255, 255);
+        ofColor rectangleColor = ofColor(255, 255, 255);
     };
     drawSettings drawSettings;
 
@@ -102,5 +102,5 @@ private:
     bool bUseMouse = false; // false before a setup
 };
 
-#endif	
+#endif
 

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -29,7 +29,7 @@ public:
 
     void reSetupWarped(int _x, int _y, int _w, int _h); // allows you to redefine base rectangle without losing the current warping.
 
-	void draw();	// nowthis method draw the bounding box for the warped elements. intended to be a visual aid.
+    void draw();	// This is deprecated (included in end()). Please check the drawSettings structure below.
 	void begin();	//changed name from draw to begin
 	void end();		//added to make it easier to use, similar to ofFbo (begin,end)
 		
@@ -79,6 +79,15 @@ public:
     float getCornerSensibility();
 
     ofParameter<glm::vec2> corners[4];
+
+    struct drawSettings{
+        bool bDrawCorners = true;
+        bool bDrawRectangle = true;
+        ofColor selectedCornerColor = ofColor(255, 0, 0);
+        ofColor cornersColor = ofColor(255, 255, 0);
+        ofColor RectangleColor = ofColor(255, 255, 255);
+    };
+    drawSettings drawSettings;
 
 private:
 	int x, y;


### PR DESCRIPTION
Hello, this is me again ;)
There should be soon nothing more to add ! 3 things here.

1) I fixed the coords functions so they refer to 0,0 of the window like everything.
There is a gif of this in action, I think this is the expected behavior in the comments, it is pretty hard to understand fully:
```
glm::vec4 ofxGLWarper::fromScreenToWarpCoord(float x, float y, float z){
    // this is the point on the image which i want to know the coordinates inside the warped system ...

glm::vec4 ofxGLWarper::fromWarpToScreenCoord(float x, float y, float z){
    // this is the point inside the warped system which i want to know the coordinates on the image  ...
```
![ofxglwarper coords](https://user-images.githubusercontent.com/8659935/43361812-563cd6a2-92db-11e8-92fa-984d0592858f.gif)

2) I added a functionality I need and I think is very useful, it is called reSetupWarped()
(if you come up with a better name....)
It allows you to redefine the base rectangle without losing the current warping. see the gif:
![resetupwarped](https://user-images.githubusercontent.com/8659935/43361846-26f1e576-92dc-11e8-9dbc-0b8695999a9b.gif)
In my case, I play videos and if the source format (4:3, 16:9,...) differs from one to another, I can change the warper to fit while keeping it warped the same.

3) Last thing, I noticed that draw() is only drawing a rectangle now. And the corners are drawn in the end() function.
Problems:
_The rectangle is drawn under the image if draw() called too soon (like in the examples).
_The function is pretty weak.
_There is no option to NOT draw the corners.
Solutions:
_We can draw the rectangle and the corners in the end() function if active=true, we get rid of calling draw() only for rect.
_We can draw the rectangle and the corners in the draw function but we add one more push/pop matrix for the corners. Someone could like it sober without the corners if he doesn't call draw().
_We don't care, it is good enough.

