### PR TITLE
fixes segfault on loading on 0.10

### DIFF
--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -197,7 +197,9 @@ void ofxGLWarper::loadFromXml(ofXml &XML, const string& warperID){
 	auto cor = c.getChildren("corner");
 	int i = 0;
 	for(auto& ch: cor){
-        corners[i] = glm::vec2(ch.getChild("x").getFloatValue(), ch.getChild("y").getFloatValue());
+        if(i<4){
+            corners[i] = glm::vec2(ch.getChild("x").getFloatValue(), ch.getChild("y").getFloatValue());
+        } 
 		i++;
     }
 


### PR DESCRIPTION
Hi, using the addon on oF 0.10 i had segfault on loading the saved .xml, so i added an additional check to avoid that. Tested on Debian 9.

Cheers!