### PR TITLE
little getter functions and bugFix

### DIFF
--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -159,7 +159,7 @@ void ofxGLWarper::end(){
     if ((drawSettings.bDrawCorners && active) || (drawSettings.bDrawCorners && drawSettings.bForceDrawing)) {// this draws colored squares over the corners as a visual aid.
         ofSetRectMode(OF_RECTMODE_CENTER);
         for (int i = 0; i < 4; i++) {
-            if(i==selectedCorner){
+            if(cornerIsSelected && i==selectedCorner){
                 ofSetColor(drawSettings.selectedCornerColor);
             }else{
                 ofSetColor(drawSettings.cornersColor);
@@ -236,10 +236,11 @@ void ofxGLWarper::mouseDragged(ofMouseEventArgs &args){
 void ofxGLWarper::mousePressed(ofMouseEventArgs &args){
 
     float smallestDist = sqrtf(ofGetWidth() * ofGetWidth() + ofGetHeight() * ofGetHeight());
-    //selectedCorner = -1;
     float sensFactor = cornerSensibility * sqrtf( width  * width  + height  * height );
 
     cornerIsSelected = false;
+    selectedCorner = -1;
+
     for(int i = 0; i < 4; i++){
         float distx = corners[i]->x - args.x;
         float disty = corners[i]->y - args.y;
@@ -385,6 +386,17 @@ glm::vec2 ofxGLWarper::getCorner(CornerLocation cornerLocation){
 //--------------------------------------------------------------
 ofRectangle ofxGLWarper::getBaseRectangle(){
     return ofRectangle(x,y,width,height); // gets you the rect used to setup
+}
+//--------------------------------------------------------------
+bool ofxGLWarper::getCornerIsSelected(){
+    return cornerIsSelected;
+}
+//--------------------------------------------------------------
+    // When no corner is selected ( getCornerIsSelected() == false ) :
+    // getSelectedCornerLocation() < static_cast<ofxGLWarper::CornerLocation>(0)
+ofxGLWarper::CornerLocation ofxGLWarper::getSelectedCornerLocation(){
+    ofxGLWarper::CornerLocation corner_loc = static_cast<ofxGLWarper::CornerLocation>(selectedCorner);
+    return corner_loc;
 }
 //--------------------------------------------------------------
 void ofxGLWarper::setCornerSensibility(float sensibility){

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -383,6 +383,10 @@ glm::vec2 ofxGLWarper::getCorner(CornerLocation cornerLocation){
     return corners[cornerLocation];// * glm::vec2(width, height);
 }
 //--------------------------------------------------------------
+ofRectangle ofxGLWarper::getBaseRectangle(){
+    return ofRectangle(x,y,width,height); // gets you the rect used to setup
+}
+//--------------------------------------------------------------
 void ofxGLWarper::setCornerSensibility(float sensibility){
     cornerSensibility = sensibility;
 }

--- a/src/ofxGLWarper.cpp
+++ b/src/ofxGLWarper.cpp
@@ -30,8 +30,7 @@ void ofxGLWarper::setup(int _x, int _y, int _w, int _h){
     y=_y;
     width=_w;
     height=_h;
-    selectedCorner = -1;
-    cornerIsSelected = false;
+    selectedCorner = -1; // == -1 when no corner is selected.
     cornerSensibility = 0.5;
     bUseKeys = true;
     bUseMouse = true;
@@ -159,7 +158,7 @@ void ofxGLWarper::end(){
     if ((drawSettings.bDrawCorners && active) || (drawSettings.bDrawCorners && drawSettings.bForceDrawing)) {// this draws colored squares over the corners as a visual aid.
         ofSetRectMode(OF_RECTMODE_CENTER);
         for (int i = 0; i < 4; i++) {
-            if(cornerIsSelected && i==selectedCorner){
+            if(i==selectedCorner){
                 ofSetColor(drawSettings.selectedCornerColor);
             }else{
                 ofSetColor(drawSettings.cornersColor);
@@ -227,10 +226,10 @@ void ofxGLWarper::loadFromXml(ofXml &XML, const string& warperID){
 }
 //--------------------------------------------------------------
 void ofxGLWarper::mouseDragged(ofMouseEventArgs &args){
-    if(cornerIsSelected && selectedCorner >= 0){
+    if(selectedCorner != -1){
         corners[selectedCorner] = glm::vec2(args.x, args.y);
+        processMatrices();
     }
-    processMatrices();
 }
 //--------------------------------------------------------------
 void ofxGLWarper::mousePressed(ofMouseEventArgs &args){
@@ -238,7 +237,6 @@ void ofxGLWarper::mousePressed(ofMouseEventArgs &args){
     float smallestDist = sqrtf(ofGetWidth() * ofGetWidth() + ofGetHeight() * ofGetHeight());
     float sensFactor = cornerSensibility * sqrtf( width  * width  + height  * height );
 
-    cornerIsSelected = false;
     selectedCorner = -1;
 
     for(int i = 0; i < 4; i++){
@@ -249,14 +247,13 @@ void ofxGLWarper::mousePressed(ofMouseEventArgs &args){
         if(dist < smallestDist && dist < sensFactor ){
             selectedCorner = i;
             smallestDist = dist;
-            cornerIsSelected=true;
         }
     }
 }
 
 //--------------------------------------------------------------
 void ofxGLWarper::keyPressed(ofKeyEventArgs &args){
-    if (cornerIsSelected && selectedCorner >= 0) {
+    if (selectedCorner != -1) {
         switch (args.key) {
             case OF_KEY_DOWN:
                 corners[selectedCorner] += glm::vec2(0,1);
@@ -389,7 +386,11 @@ ofRectangle ofxGLWarper::getBaseRectangle(){
 }
 //--------------------------------------------------------------
 bool ofxGLWarper::getCornerIsSelected(){
-    return cornerIsSelected;
+    if (selectedCorner != -1){
+        return true;
+    }else{
+        return false;
+    }
 }
 //--------------------------------------------------------------
     // When no corner is selected ( getCornerIsSelected() == false ) :

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -76,7 +76,10 @@ public:
     void setAllCorners(glm::vec2 &top_left, glm::vec2 &top_right, glm::vec2 &bot_left, glm::vec2 &bot_right);
     void moveAllCorners(glm::vec2 &moveBy);
     void moveAllCorners(float byX, float byY);
+
     ofRectangle getBaseRectangle(); // gets you the rect used to setup
+    bool getCornerIsSelected();
+    CornerLocation getSelectedCornerLocation();
 
     void setCornerSensibility(float sensibility);
     float getCornerSensibility();

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -76,6 +76,7 @@ public:
     void setAllCorners(glm::vec2 &top_left, glm::vec2 &top_right, glm::vec2 &bot_left, glm::vec2 &bot_right);
     void moveAllCorners(glm::vec2 &moveBy);
     void moveAllCorners(float byX, float byY);
+    ofRectangle getBaseRectangle(); // gets you the rect used to setup
 
     void setCornerSensibility(float sensibility);
     float getCornerSensibility();

--- a/src/ofxGLWarper.h
+++ b/src/ofxGLWarper.h
@@ -104,7 +104,6 @@ private:
     int selectedCorner;
     glm::mat4 myMatrix;
     float cornerSensibility;
-    bool cornerIsSelected;
     bool bUseKeys = false; // false before a setup
     bool bUseMouse = false; // false before a setup
 };


### PR DESCRIPTION
Hey, there was a small bug, previously selected corner was still drawn in red. It is corrected here.
I added a get function for the Base Rectangle used to setup, and for the selected corner enum.

I was thinking of something but I warped my head around it but maybe it is impossible.
Maybe you have an idea : 
I would like to add a function that, when you define 3 corners, can extrapolate the 4th position.
Because the Base Rectangle is known and to keep the ratio in space there should be only 1 possible position ?? I am not sure to be right, and also I can't find any helping formula on the web.
Maybe you have a clearer idea if it is possible or not.
The thing is that I don't have the Z-axis equivalent position of the corners they're all at 0.